### PR TITLE
Fixed IDA get error

### DIFF
--- a/src/CodeGeneration/CodeGeneration.jl
+++ b/src/CodeGeneration/CodeGeneration.jl
@@ -288,7 +288,7 @@ function eqToJulia(eq::BDAE.Equation, simCode::SimulationCode.SIM_CODE, resNumbe
         end
         $(Symbol("cb$(CALLBACK_COUNTER)")) = ContinuousCallback($(Symbol("condition$(CALLBACK_COUNTER)")), 
                                                                 $(Symbol("affect$(CALLBACK_COUNTER)!")),
-                                                                rootfind=true, save_positions=(false,true),
+                                                                rootfind=true, save_positions=(false, false),
                                                                 affect_neg! = $(Symbol("affect$(CALLBACK_COUNTER)!")),)
       end
     end


### PR DESCRIPTION
When executing callbacks with save_posistions. 

The following error is triggered: 
```

┌ Warning: IDAGetDky failed with error code =
│   flag = -25
└ @ Sundials C:\Users\John\.julia\packages\Sundials\xAoTr\src\simple.jl:20

```

This avoids this issue for now.. 