### PR TITLE
Fixed issue with the remapping of initial values

### DIFF
--- a/src/Runtime/Runtime.jl
+++ b/src/Runtime/Runtime.jl
@@ -68,10 +68,10 @@ mutable struct StructuralChangeRecompilation{MOD <: Tuple} <: AbstractStructural
   metaModel::SCode.CLASS
   "The modification to be applied during recompilation"
   modification::MOD
-  "
+  """
   The symbol table for the old model.
   This is used to map indices of variables when the structure of the model changes
-  "
+  """
   stringToSimVarHT
 end
 
@@ -226,6 +226,7 @@ function solve(omProblem::OM_ProblemRecompilation, tspan, alg; kwargs...)
       for cb in structuralCallbacks
         if cb.structureChanged && i.t < tspan[2]
           #= Recompile the system =#
+          local oldHT = cb.stringToSimVarHT
           (newProblem, newSymbolTable, initialValues) = recompilation(cb.name, cb, integrator.u, tspan, callbackConditions)
           #= End recompilation =#
           #= Assuming the indices are the same (Which is not neccesary true) =#
@@ -233,7 +234,7 @@ function solve(omProblem::OM_ProblemRecompilation, tspan, alg; kwargs...)
           local symsOfNewProlem = getSyms(newProblem)
           local newU0 = RuntimeUtil.createNewU0(symsOfOldProblem,
                                                 symsOfNewProlem,
-                                                cb.stringToSimVarHT,
+                                                oldHT,
                                                 newSymbolTable,
                                                 initialValues,
                                                 integrator)
@@ -266,7 +267,6 @@ function solve(omProblem::OM_ProblemRecompilation, tspan, alg; kwargs...)
         end
       end
     end
-#  end
   @label END_OF_INTEGRATION
   push!(solutions, integrator.sol)
   return solutions

--- a/src/Runtime/RuntimeUtil.jl
+++ b/src/Runtime/RuntimeUtil.jl
@@ -74,7 +74,7 @@ function convertSymbolsToStrings(symbols::Vector{Symbol})
 end
 
 """
-  This function maps variables between two models during a structural change.
+  This function maps variables between two models during a structural change with recompilation.
   It returns a new vector of u₀ variables to initialize the new model.
   We do so by assigning the old values when the structural change occured for all variables
   that occured in the model before the structural change.


### PR DESCRIPTION
This resolves an issue where the mapping of initial conditions due to structural changes fail.
The old HT is no longer overwritten