### PR TITLE
Fix Windows libgio DLL clash: load Plots before OMRuntimeExternalC

### DIFF
--- a/src/OMBackend.jl
+++ b/src/OMBackend.jl
@@ -30,6 +30,13 @@
 */ =#
 
 module OMBackend
+# Load Plots (and through it Glib's gettext runtime) BEFORE any include that pulls
+# in OMRuntimeExternalC. On Windows, OMRuntimeExternalC loads its own bundled
+# libintl-8.dll/libiconv-2.dll into the process; if that happens first, Glib's
+# libgio-2.0-0.dll later binds against the older gettext and fails to load with
+# "the specified procedure could not be found". Loading Plots first makes Glib's
+# gettext win the libintl-8.dll name, which OMRuntimeExternalC tolerates.
+import Plots
 import DAE
 using MetaModelica: @assign
 const CURRENT_DIRECTORY = @__DIR__

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -52,6 +52,16 @@
     ccall((:SetErrorMode, "kernel32.dll"), UInt32, (UInt32,), 0x8003)
 end
 
+# Load Plots (and through it Glib's gettext runtime) FIRST in the test process,
+# before OMBackend — which pulls in OMRuntimeExternalC and its bundled
+# libintl-8.dll. On Windows, whichever libintl-8.dll loads first wins the name;
+# if OMRuntimeExternalC's loads first, Glib's libgio-2.0-0.dll later fails with
+# "the specified procedure could not be found". Preloading Plots here forces Glib's
+# gettext to win regardless of the package __init__ order, which (unlike the
+# in-module import in OMBackend) is not guaranteed when loading the precompiled
+# package on CI.
+import Plots
+
 import Absyn
 import SCode
 import DAE

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,16 @@
   the top-level OM.jl test suite at /test/runtests.jl.
 =#
 
+# On Windows, a failed DLL load or a segfault in external Modelica C functions
+# opens a modal Windows Error Reporting dialog. On a headless CI runner nothing
+# clicks it away, so the test process hangs until the job timeout (a silent
+# ~90 min stall). Disable those hard-error popups so such a failure crashes/errors
+# visibly in the log instead of blocking. (SEM_FAILCRITICALERRORS |
+# SEM_NOGPFAULTERRORBOX | SEM_NOOPENFILEERRORBOX = 0x8003.)
+@static if Sys.iswindows()
+    ccall((:SetErrorMode, "kernel32.dll"), UInt32, (UInt32,), 0x8003)
+end
+
 import Absyn
 import SCode
 import DAE


### PR DESCRIPTION
## Summary

Fixes a **Windows-only** DLL-load failure (and blocking error popup) when building/loading the OM.jl umbrella, where precompilation/loading dies with:

```
could not load library "...\artifacts\...\libgio-2.0-0.dll"
The specified procedure could not be found.
```

## Root cause

OMRuntimeExternalC loads its own bundled mingw `libintl-8.dll` / `libiconv-2.dll` into the process. On Windows, DLLs are keyed by module name, so whichever `libintl-8.dll` loads first "wins". If OMRuntimeExternalC loads before Glib, Glib's `libgio-2.0-0.dll` then binds against that older gettext runtime and can't resolve an entry point it needs â†’ failed load.

- **Order-dependent** (hence it looked intermittent / "flaky").
- **Windows-only** â€” Linux resolves each `.so` against its own RPATH, so there's no clash (confirmed: on the Linux CI, `GettextRuntime_jll` and OMBackend precompile cleanly).

Proven via `Libdl.dllist()` (ORC's `libintl-8.dll`/`libiconv-2.dll` resident after `import OMRuntimeExternalC`) and reproducible ordering: `Plots`-alone OK, `ORCâ†’Plots` fails 2/2, `Plotsâ†’ORC` OK.

## Fix

`import Plots` at the top of the `OMBackend` module, before the includes that pull in OMRuntimeExternalC, so Glib's gettext loads first. OMRuntimeExternalC tolerates the newer runtime.

## Verification

Full OM.jl umbrella on **Windows + Julia 1.12.6**: `install_dev` precompile **exit 0**, and `using OM` loads cleanly (no popup), with `OMBackend.CodeGeneration._buildDirectODEFunction` present.

> Note: this is a pragmatic load-order fix. The cleaner long-term fix would be for OMRuntimeExternalC to not ship/leak `libintl-8.dll` into the global process namespace.

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
